### PR TITLE
Fix import path in configuration checker

### DIFF
--- a/check_config.py
+++ b/check_config.py
@@ -5,7 +5,13 @@ Check configuration and models directory
 
 import sys
 import os
-sys.path.append('/app')
+
+# Add the backend directory to the Python path so the `app` package can be
+# imported when running this script directly from the repository root.
+REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
+BACKEND_PATH = os.path.join(REPO_ROOT, "backend")
+if BACKEND_PATH not in sys.path:
+    sys.path.append(BACKEND_PATH)
 
 from app.core.config import settings
 


### PR DESCRIPTION
## Summary
- fix the Python path setup in `check_config.py`

## Testing
- `python3 check_config.py`
- `python3 -m pytest backend/tests/test_validation_service.py::test_validation_service -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_6844f80f84c8832b90b07956373835f7